### PR TITLE
Add paypal_commerce_platform as a payment method

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/gateway.rb
+++ b/app/models/solidus_paypal_commerce_platform/gateway.rb
@@ -1,0 +1,5 @@
+module SolidusPaypalCommercePlatform
+  class Gateway < SolidusSupport.payment_method_parent_class
+
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,4 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
 en:
-  hello: Hello world
+  activerecord:
+    models:
+      solidus_paypal_commerce_platform/gateway: Paypal Commerce Platform

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -11,6 +11,10 @@ module SolidusPaypalCommercePlatform
 
     engine_name 'solidus_paypal_commerce_platform'
 
+    initializer "register_solidus_paypal_commerce_platform_gateway", after: "spree.register.payment_methods" do |app|
+      app.config.spree.payment_methods << SolidusPaypalCommercePlatform::Gateway
+    end
+
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec

--- a/spec/features/backend/new_payment_method_spec.rb
+++ b/spec/features/backend/new_payment_method_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe "creating a new payment" do
+  stub_authorization!
+
+  scenario "should display PayPal Commerce Platform as an option" do
+    visit "/admin/payment_methods/new"
+    expect(page).to have_select('payment_method_type', :options => ["Paypal Commerce Platform", "Bogus Credit Card Payments", "Check Payments", "Simple Bogus Credit Card Payments", "Store Credit Payments"])
+  end
+end


### PR DESCRIPTION
Adds the model and translation for paypal_commerce_platform and
inserts it into the available payment_methods for solidus.