### PR TITLE
Add ability for admin users to customize paypal button

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
@@ -1,5 +1,6 @@
-SolidusPaypalCommercePlatform.renderButton = function(payment_method_id) {
+SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) {
   paypal.Buttons({
+    style: style,
     createOrder: function (data, actions) {
       return Spree.ajax({
         url: '/solidus_paypal_commerce_platform/orders',

--- a/app/helpers/solidus_paypal_commerce_platform/button_options_helper.rb
+++ b/app/helpers/solidus_paypal_commerce_platform/button_options_helper.rb
@@ -1,0 +1,21 @@
+module SolidusPaypalCommercePlatform
+  module ButtonOptionsHelper
+
+    def preferred_paypal_button_color_options
+      [["Gold","gold"],["Blue","blue"],["Silver","silver"],["White","white"],["Black","black"]]
+    end
+
+    def preferred_paypal_button_size_options
+      [["Small","small"],["Medium","medium"],["Large","large"],["Responsive","responsive"]]
+    end
+
+    def preferred_paypal_button_shape_options
+      [["Pill","pill"],["Rectangular","rect"]]
+    end
+
+    def preferred_paypal_button_layout_options
+      [["Vertical","vertical"],["Horizontal","horizontal"]]
+    end
+
+  end
+end

--- a/app/models/solidus_paypal_commerce_platform/gateway.rb
+++ b/app/models/solidus_paypal_commerce_platform/gateway.rb
@@ -1,7 +1,12 @@
 module SolidusPaypalCommercePlatform
   class Gateway < SolidusSupport.payment_method_parent_class
+    include SolidusPaypalCommercePlatform::ButtonOptionsHelper
     preference :client_id, :string
     preference :client_secret, :string
+    preference :paypal_button_color, :paypal_select, default: "gold"
+    preference :paypal_button_size, :paypal_select, default: "responsive"
+    preference :paypal_button_shape, :paypal_select, default: "rect"
+    preference :paypal_button_layout, :paypal_select, default: "vertical"
 
     def partial_name
       "paypal_commerce_platform"
@@ -39,6 +44,15 @@ module SolidusPaypalCommercePlatform
 
     def request
       Requests.new(client_id, client_secret)
+    end
+
+    def button_style
+      {
+        color: preferences[:paypal_button_color],
+        size: preferences[:paypal_button_size],
+        shape: preferences[:paypal_button_shape],
+        layout: preferences[:paypal_button_layout]
+      }
     end
 
     def sdk_url

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -13,6 +13,7 @@ module SolidusPaypalCommercePlatform
 
     initializer "register_solidus_paypal_commerce_platform_gateway", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << SolidusPaypalCommercePlatform::Gateway
+      SolidusPaypalCommercePlatform::Gateway.allowed_admin_form_preference_types << :paypal_select
       Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id]
     end
 

--- a/lib/views/backend/spree/admin/shared/preference_fields/_paypal_select.html.erb
+++ b/lib/views/backend/spree/admin/shared/preference_fields/_paypal_select.html.erb
@@ -1,0 +1,13 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {class: 'custom-select fullwidth'}.update(local_assigns[:html_options] || {}) %>
+<% options = @object.send("#{attribute}_options") %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.select attribute, options, {}, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= select_tag name, value, html_options %>
+  <% end %>
+</div>

--- a/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
@@ -7,6 +7,6 @@
 
 <script>
   $( document ).ready(function() {
-    SolidusPaypalCommercePlatform.renderButton("<%= payment_method.id %>")
+    SolidusPaypalCommercePlatform.renderButton("<%= payment_method.id %>",<%= raw payment_method.button_style.to_json %>)
   })
 </script>


### PR DESCRIPTION
I utilize the preference_fields, creating a custom one for a select option. I also provide defaults for
all of the button options based on the defaults PayPal recommends selecting, while adding a helper
that provides the collection of other available options. All of this is displayed on the PCP
payment method page on admin. The options are passed on the frontend when we display the PayPal button.

**NOTE**: This PR requires #10 to be merged first, as it adds some options to the frontend button that that PR adds. Once #10 is merged, I'll rebase this PR and it should be good to go!

Ref: #5 