### PR TITLE
Add refund ability to admin payment management

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/gateway.rb
+++ b/app/models/solidus_paypal_commerce_platform/gateway.rb
@@ -29,7 +29,9 @@ module SolidusPaypalCommercePlatform
     end
 
     def purchase(money, source, options)
-      request.capture_order(source.paypal_order_id)
+      result = request.capture_order(source.paypal_order_id)
+      source.update(capture_id: result.id)
+      result
     end
 
     def authorize(money, source, options)
@@ -39,7 +41,13 @@ module SolidusPaypalCommercePlatform
     end
 
     def capture(money, response_code, options)
-      request.capture_authorized_order(options[:originator].source.authorization_id)
+      result = request.capture_authorized_order(options[:originator].source.authorization_id)
+      options[:originator].source.update(capture_id: result.id)
+      result
+    end
+
+    def credit(money_cents, transaction_id, options)
+      request.refund_order(options[:originator])
     end
 
     def void(response_code, options)

--- a/app/models/solidus_paypal_commerce_platform/source.rb
+++ b/app/models/solidus_paypal_commerce_platform/source.rb
@@ -16,7 +16,16 @@ module SolidusPaypalCommercePlatform
     end
 
     def can_credit?(payment)
-      false
+      payment.completed? && 
+      payment.credit_allowed > 0 && 
+      capture_id && 
+      request.get_order(paypal_order_id).status == "COMPLETED"
+    end
+
+    private
+
+    def request
+      SolidusPaypalCommercePlatform::Requests.new(payment_method.client_id, payment_method.client_secret)
     end
 
   end

--- a/db/migrate/20200521190038_add_paypal_commerce_platform_sources.rb
+++ b/db/migrate/20200521190038_add_paypal_commerce_platform_sources.rb
@@ -4,6 +4,7 @@ class AddPaypalCommercePlatformSources < ActiveRecord::Migration[5.2]
       t.string :paypal_order_id
       t.integer :payment_method_id
       t.string :authorization_id
+      t.string :capture_id
       t.timestamps
     end
   end


### PR DESCRIPTION
Adds ability to refund payments on PayPal. This requires having a `capture_id`
from PayPal stored whenever the payment is captured, since the route
to refund involves the capture_id.