### PR TITLE
Fix order controller response

### DIFF
--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -6,8 +6,7 @@ module SolidusPaypalCommercePlatform
 
     def create
       authorize! :update, @order, order_token
-      @payment_method.request.create_order(@order, @payment_method.auto_capture)
-      render json: request, status: :ok
+      render json: @payment_method.request.create_order(@order, @payment_method.auto_capture), status: :ok
     end
 
     private


### PR DESCRIPTION
Order controller used to define a `request` variable and returned that.
However, now it's just returning `request` as in the browser request, which
is breaking things. I've removed the variable, so we're directly returning
the response of the post request.