### PR TITLE
Add PayPal Virtual Terminal notice to backend

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,3 +9,4 @@ en:
   sign_up_for_paypal: Setup PayPal Commerce Platform
   start_paying_with_paypal: Start paying with Paypal Commerce Platform
   paypal_order_id: PayPal Order ID
+  virtual_terminal_notice_html: Backend Credit Card payments can only be accepted through PayPal via the <a href="https://www.paypal.com/merchantapps/appcenter/acceptpayments/virtualterminal">PayPal Virtual Terminal</a>.

--- a/lib/views/backend/spree/admin/payments/source_forms/_paypal_commerce_platform.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_forms/_paypal_commerce_platform.html.erb
@@ -1,0 +1,1 @@
+<%= t('virtual_terminal_notice_html') %>


### PR DESCRIPTION
Adds a notice to backend payments create that you can't create PayPal
payments on the backend, only through virtual terminal. So convenient!

Ref #15 

I played around with the idea of a button that creates a bogus payment once the payment has been made via the virtual terminal, but I think the two ways of doing that:
* We assume the user has the BogusCreditCard payment method
* We create a PCP payment with fake/missing credentials
could cause more problems than they solve.

So I've just opted to add a text notice that admin users can't add payments through the admin interface for PayPal. Let me know how this looks or if you can think of any alternatives! Thanks!