### PR TITLE
Add response object to API calls to PayPal

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/response.rb
+++ b/app/models/solidus_paypal_commerce_platform/response.rb
@@ -1,0 +1,14 @@
+module SolidusPaypalCommercePlatform
+  class Response < ActiveMerchant::Billing::Response
+    DESIRED_STATUS_CODES = [201, 204]
+
+    def initialize(response, success_message)
+      if DESIRED_STATUS_CODES.include? response.status_code
+        super(true, success_message, {result: response.result})
+      else
+        super(false, "A problem has occurred with this payment, please try again.")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
The response objects allow us to add messages to success responses,
which can be viewed from the admin payment show page. They also
allow us to define failure messages, and returning a failing
response object like this will also prevent people from checking
out with bogus payment information as described in #19 