### PR TITLE
Use "commit=false" in the JS SDK url when "confirm" step is present

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -37,13 +37,19 @@ module SolidusPaypalCommercePlatform
       }
     end
 
-    def sdk_url
+    def javascript_sdk_url(order: nil)
+      # Both instance and class respond to checkout_steps.
+      step_names = order ? order.checkout_steps : Spree::Order.checkout_steps.keys
+
+      commit_immediately = step_names.include? "confirm"
+
       parameters = {
         'client-id': client_id,
-        intent: auto_capture ? "capture" : "authorize"
+        intent: auto_capture ? "capture" : "authorize",
+        commit: commit_immediately ? "false" : "true",
       }
 
-      URI("https://www.paypal.com/sdk/js?"+parameters.to_query)
+      "https://www.paypal.com/sdk/js?#{parameters.to_query}"
     end
 
   end

--- a/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
@@ -1,6 +1,4 @@
-<script
-  src="<%= payment_method.sdk_url %>">
-</script>
+<script src="<%= payment_method.javascript_sdk_url(order: @order) %>"></script>
 
 <div id="paypal-button-container"></div>
 <input type="hidden" name="payment_source[<%= payment_method.id %>][paypal_order_id]" id="payments_source_paypal_order_id">

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -15,20 +15,22 @@ RSpec.describe "Checkout" do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order, try_spree_current_user: user)
     end
 
+    def paypal_script_options
+      script_tag_url = URI(page.find('script[src*="sdk/js?"]', visible: false)[:src])
+      script_tag_url.query.split('&')
+    end
+
     it "should generate a js file with the correct credentials and intent attached" do
       visit '/checkout/payment'
-      expect(page).to have_css(
-        'script[src*="sdk/js?client-id=' + paypal_payment_method.preferences[:client_id] + '&intent=authorize"]', visible: false
-        )
+      expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
     end
 
     context "when auto-capture is set to true" do
       it "should generate a js file with intent capture" do
         paypal_payment_method.update(auto_capture: true)
         visit '/checkout/payment'
-        expect(page).to have_css(
-          'script[src*="sdk/js?client-id=' + paypal_payment_method.preferences[:client_id] + '&intent=capture"]', visible: false
-          )
+        expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+        expect(paypal_script_options).to include("intent=capture")
       end
     end
 

--- a/spec/models/payment_method_spec.rb
+++ b/spec/models/payment_method_spec.rb
@@ -130,4 +130,24 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
       paypal_payment_method.credit(1000,{},{originator: completed_payment.refunds.new(amount:12)})
     end
   end
+
+  describe '.javascript_sdk_url' do
+    subject(:url) { URI(paypal_payment_method.javascript_sdk_url(order: order)) }
+
+    context 'when checkout_steps include "confirm"' do
+      let(:order) { double("order", checkout_steps: {"confirm" => "bar"}) }
+
+      it 'sets autocommit' do
+        expect(url.query.split("&")).to include("commit=false")
+      end
+    end
+
+    context 'when checkout_steps does not include "confirm"' do
+      let(:order) { double("order", checkout_steps: {"foo" => "bar"}) }
+
+      it 'disables autocommit' do
+        expect(url.query.split("&")).to include("commit=true")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #18