### PR TITLE
Enable use with Rack Basic Auth

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -14,7 +14,7 @@ SolidusPaypalCommercePlatform.handleError = function(error) {
 
 SolidusPaypalCommercePlatform.sendOrder = function(payment_method_id) {
   return Spree.ajax({
-    url: '/solidus_paypal_commerce_platform/paypal_orders/' + Spree.current_order_id,
+    url: Spree.pathFor('solidus_paypal_commerce_platform/paypal_orders/' + Spree.current_order_id),
     method: 'GET',
     data: {
       payment_method_id: payment_method_id,
@@ -44,7 +44,7 @@ SolidusPaypalCommercePlatform.createOrder = function() {
   }
 
   return Spree.ajax({
-    url: "/solidus_paypal_commerce_platform/orders",
+    url: Spree.pathFor("solidus_paypal_commerce_platform/orders"),
     method: 'POST',
     data: data,
     error: function(response) {
@@ -92,7 +92,7 @@ SolidusPaypalCommercePlatform.approveOrder = function(data, actions) {
 
 SolidusPaypalCommercePlatform.shippingChange = function(data, actions) {
   Spree.ajax({
-    url: '/solidus_paypal_commerce_platform/shipping_rates',
+    url: Spree.pathFor('solidus_paypal_commerce_platform/shipping_rates'),
     method: 'GET',
     data: {
       order_id: Spree.current_order_id,
@@ -113,7 +113,7 @@ SolidusPaypalCommercePlatform.shippingChange = function(data, actions) {
 
 SolidusPaypalCommercePlatform.verifyTotal = function(paypal_total) {
   return Spree.ajax({
-    url: '/solidus_paypal_commerce_platform/verify_total',
+    url: Spree.pathFor('solidus_paypal_commerce_platform/verify_total'),
     method: 'GET',
     data: {
       order_id: Spree.current_order_id,
@@ -145,7 +145,7 @@ SolidusPaypalCommercePlatform.finalizeOrder = function(payment_method_id, data, 
 
 SolidusPaypalCommercePlatform.advanceOrder = function() {
   return Spree.ajax({
-    url: '/api/checkouts/' + Spree.current_order_id + '/advance',
+    url: Spree.pathFor('api/checkouts/' + Spree.current_order_id + '/advance'),
     method: 'PUT',
     data: {
       order_token: Spree.current_order_token
@@ -159,7 +159,7 @@ SolidusPaypalCommercePlatform.advanceOrder = function() {
 
 SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_method_id, data, email) {
   return Spree.ajax({
-    url: '/api/checkouts/' + Spree.current_order_id + '/payments',
+    url: Spree.pathFor('api/checkouts/' + Spree.current_order_id + '/payments'),
     method: 'POST',
     data: {
       order_token: Spree.current_order_token,
@@ -179,10 +179,10 @@ SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_metho
   })
 }
 
-SolidusPaypalCommercePlatform.updateAddress = function(response) { 
+SolidusPaypalCommercePlatform.updateAddress = function(response) {
   var updated_address = response.purchase_units[0].shipping.address
   return Spree.ajax({
-    url: '/solidus_paypal_commerce_platform/update_address',
+    url: Spree.pathFor('solidus_paypal_commerce_platform/update_address'),
     method: 'POST',
     data: {
       address: {

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js.erb
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js.erb
@@ -1,3 +1,5 @@
+SolidusPaypalCommercePlatform.basic_auth = "<%= ENV['BASIC_AUTH'] %>"
+
 SolidusPaypalCommercePlatform.showOverlay = function() {
   document.getElementById("paypal_commerce_platform_overlay").style.display = "block";
 }
@@ -16,6 +18,11 @@ SolidusPaypalCommercePlatform.sendOrder = function(payment_method_id) {
   return Spree.ajax({
     url: Spree.pathFor('solidus_paypal_commerce_platform/paypal_orders/' + Spree.current_order_id),
     method: 'GET',
+    beforeSend: function (xhr) {
+      if (SolidusPaypalCommercePlatform.basic_auth) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(SolidusPaypalCommercePlatform.basic_auth));
+      }
+    },
     data: {
       payment_method_id: payment_method_id,
       order_token: Spree.current_order_token
@@ -46,6 +53,11 @@ SolidusPaypalCommercePlatform.createOrder = function() {
   return Spree.ajax({
     url: Spree.pathFor("solidus_paypal_commerce_platform/orders"),
     method: 'POST',
+    beforeSend: function (xhr) {
+      if (SolidusPaypalCommercePlatform.basic_auth) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(SolidusPaypalCommercePlatform.basic_auth));
+      }
+    },
     data: data,
     error: function(response) {
       message = response.responseJSON
@@ -94,6 +106,11 @@ SolidusPaypalCommercePlatform.shippingChange = function(data, actions) {
   Spree.ajax({
     url: Spree.pathFor('solidus_paypal_commerce_platform/shipping_rates'),
     method: 'GET',
+    beforeSend: function (xhr) {
+      if (SolidusPaypalCommercePlatform.basic_auth) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(SolidusPaypalCommercePlatform.basic_auth));
+      }
+    },
     data: {
       order_id: Spree.current_order_id,
       order_token: Spree.current_order_token,
@@ -115,6 +132,11 @@ SolidusPaypalCommercePlatform.verifyTotal = function(paypal_total) {
   return Spree.ajax({
     url: Spree.pathFor('solidus_paypal_commerce_platform/verify_total'),
     method: 'GET',
+    beforeSend: function (xhr) {
+      if (SolidusPaypalCommercePlatform.basic_auth) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(SolidusPaypalCommercePlatform.basic_auth));
+      }
+    },
     data: {
       order_id: Spree.current_order_id,
       order_token: Spree.current_order_token,
@@ -147,6 +169,11 @@ SolidusPaypalCommercePlatform.advanceOrder = function() {
   return Spree.ajax({
     url: Spree.pathFor('api/checkouts/' + Spree.current_order_id + '/advance'),
     method: 'PUT',
+    beforeSend: function (xhr) {
+      if (SolidusPaypalCommercePlatform.basic_auth) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(SolidusPaypalCommercePlatform.basic_auth));
+      }
+    },
     data: {
       order_token: Spree.current_order_token
     },
@@ -161,6 +188,11 @@ SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_metho
   return Spree.ajax({
     url: Spree.pathFor('api/checkouts/' + Spree.current_order_id + '/payments'),
     method: 'POST',
+    beforeSend: function (xhr) {
+      if (SolidusPaypalCommercePlatform.basic_auth) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(SolidusPaypalCommercePlatform.basic_auth));
+      }
+    },
     data: {
       order_token: Spree.current_order_token,
       payment: {
@@ -184,6 +216,11 @@ SolidusPaypalCommercePlatform.updateAddress = function(response) {
   return Spree.ajax({
     url: Spree.pathFor('solidus_paypal_commerce_platform/update_address'),
     method: 'POST',
+    beforeSend: function (xhr) {
+      if (SolidusPaypalCommercePlatform.basic_auth) {
+        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(SolidusPaypalCommercePlatform.basic_auth));
+      }
+    },
     data: {
       address: {
         updated_address: updated_address,

--- a/lib/solidus_paypal_commerce_platform.rb
+++ b/lib/solidus_paypal_commerce_platform.rb
@@ -7,6 +7,7 @@ require 'solidus_paypal_commerce_platform/client'
 require 'solidus_paypal_commerce_platform/configuration'
 require 'solidus_paypal_commerce_platform/version'
 require 'solidus_paypal_commerce_platform/engine'
+require 'solidus_paypal_commerce_platform/basic_auth' if Rails.env == 'test'
 
 module SolidusPaypalCommercePlatform
   class << self

--- a/lib/solidus_paypal_commerce_platform.rb
+++ b/lib/solidus_paypal_commerce_platform.rb
@@ -7,7 +7,7 @@ require 'solidus_paypal_commerce_platform/client'
 require 'solidus_paypal_commerce_platform/configuration'
 require 'solidus_paypal_commerce_platform/version'
 require 'solidus_paypal_commerce_platform/engine'
-require 'solidus_paypal_commerce_platform/basic_auth' if Rails.env == 'test'
+require 'solidus_paypal_commerce_platform/basic_auth' if Rails.env.test?
 
 module SolidusPaypalCommercePlatform
   class << self

--- a/lib/solidus_paypal_commerce_platform/basic_auth.rb
+++ b/lib/solidus_paypal_commerce_platform/basic_auth.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module SolidusPaypalCommercePlatform
   class AddRackAuthBasic < Rails::Railtie
     initializer "basic_auth.enable_rack_middleware" do |app|
       if ENV['BASIC_AUTH'].present?
         app.middleware.use ::Rack::Auth::Basic do |u, p|
-          [u, p] == ENV['BASIC_AUTH'].split(':')
+          ENV['BASIC_AUTH'].split(':') == [u, p]
         end
       end
     end

--- a/lib/solidus_paypal_commerce_platform/basic_auth.rb
+++ b/lib/solidus_paypal_commerce_platform/basic_auth.rb
@@ -1,0 +1,11 @@
+module SolidusPaypalCommercePlatform
+  class AddRackAuthBasic < Rails::Railtie
+    initializer "basic_auth.enable_rack_middleware" do |app|
+      if ENV['BASIC_AUTH'].present?
+        app.middleware.use ::Rack::Auth::Basic do |u, p|
+          [u, p] == ENV['BASIC_AUTH'].split(':')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/backend/new_payment_method_spec.rb
+++ b/spec/features/backend/new_payment_method_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe "creating a new payment" do
   stub_authorization!
 
   it "displays PayPal Commerce Platform as an option" do
+    if ENV['BASIC_AUTH'].present?
+      name, password = ENV['BASIC_AUTH'].split(':')
+      page.driver.browser.authorize(name, password)
+    end
     visit "/admin/payment_methods/new"
     expect(page).to have_select('payment_method_type', options: [
       "PayPal Commerce Platform",
@@ -24,6 +28,10 @@ RSpec.describe "creating a new payment" do
   end
 
   it "displays the onboarding button", :js do
+    if ENV['BASIC_AUTH'].present?
+      name, password = ENV['BASIC_AUTH'].split(':')
+      page.driver.basic_authorize(name, password)
+    end
     visit "/admin/payment_methods"
 
     # main_window = current_window

--- a/spec/features/backend/new_payment_method_spec.rb
+++ b/spec/features/backend/new_payment_method_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe "creating a new payment" do
   stub_authorization!
 
   it "displays PayPal Commerce Platform as an option" do
-    if ENV['BASIC_AUTH'].present?
-      name, password = ENV['BASIC_AUTH'].split(':')
-      page.driver.browser.authorize(name, password)
-    end
+    http_login_if_needed
     visit "/admin/payment_methods/new"
     expect(page).to have_select('payment_method_type', options: [
       "PayPal Commerce Platform",
@@ -28,10 +25,7 @@ RSpec.describe "creating a new payment" do
   end
 
   it "displays the onboarding button", :js do
-    if ENV['BASIC_AUTH'].present?
-      name, password = ENV['BASIC_AUTH'].split(':')
-      page.driver.basic_authorize(name, password)
-    end
+    http_login_if_needed_js
     visit "/admin/payment_methods"
 
     # main_window = current_window

--- a/spec/features/frontend/cart_spec.rb
+++ b/spec/features/frontend/cart_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe "Cart page" do
+  before do
+    if ENV['BASIC_AUTH'].present?
+      name, password = ENV['BASIC_AUTH'].split(':')
+      page.driver.browser.authorize(name, password)
+    end
+  end
   describe "paypal payment method" do
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:address) }
     let(:paypal_payment_method) { create(:paypal_payment_method) }

--- a/spec/features/frontend/cart_spec.rb
+++ b/spec/features/frontend/cart_spec.rb
@@ -2,11 +2,9 @@ require 'spec_helper'
 
 RSpec.describe "Cart page" do
   before do
-    if ENV['BASIC_AUTH'].present?
-      name, password = ENV['BASIC_AUTH'].split(':')
-      page.driver.browser.authorize(name, password)
-    end
+    http_login_if_needed
   end
+
   describe "paypal payment method" do
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:address) }
     let(:paypal_payment_method) { create(:paypal_payment_method) }

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe "Checkout" do
+  before do
+    if ENV['BASIC_AUTH'].present?
+      name, password = ENV['BASIC_AUTH'].split(':')
+      page.driver.browser.authorize(name, password)
+    end
+  end
   describe "paypal payment method" do
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
     let(:paypal_payment_method) { create(:paypal_payment_method) }

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -2,11 +2,9 @@ require 'spec_helper'
 
 RSpec.describe "Checkout" do
   before do
-    if ENV['BASIC_AUTH'].present?
-      name, password = ENV['BASIC_AUTH'].split(':')
-      page.driver.browser.authorize(name, password)
-    end
+    http_login_if_needed
   end
+
   describe "paypal payment method" do
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
     let(:paypal_payment_method) { create(:paypal_payment_method) }

--- a/spec/features/frontend/product_spec.rb
+++ b/spec/features/frontend/product_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe "Product page", js: true do
+  before do
+    if ENV['BASIC_AUTH'].present?
+      name, password = ENV['BASIC_AUTH'].split(':')
+      page.driver.basic_authorize(name, password)
+    end
+  end
   describe "paypal button" do
     let(:paypal_payment_method) { create(:paypal_payment_method) }
     let(:product) { create(:product, variants: [variant, variant_two]) }

--- a/spec/features/frontend/product_spec.rb
+++ b/spec/features/frontend/product_spec.rb
@@ -2,11 +2,9 @@ require 'spec_helper'
 
 RSpec.describe "Product page", js: true do
   before do
-    if ENV['BASIC_AUTH'].present?
-      name, password = ENV['BASIC_AUTH'].split(':')
-      page.driver.basic_authorize(name, password)
-    end
+    http_login_if_needed_js
   end
+
   describe "paypal button" do
     let(:paypal_payment_method) { create(:paypal_payment_method) }
     let(:product) { create(:product, variants: [variant, variant_two]) }

--- a/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper'
 RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request do
   stub_authorization!
   let(:order) { create(:order_with_line_items) }
-  let(:auth_headers) {
-    ENV['BASIC_AUTH'].present? ? { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(ENV['BASIC_AUTH'].split(':')[0], ENV['BASIC_AUTH'].split(':')[1]) } : {}
-  }
 
   describe "GET /solidus_paypal_commerce_platform/verify_total" do
     context "when the amount is correct" do
@@ -16,7 +13,7 @@ RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request d
           format: :json
         }
 
-        get solidus_paypal_commerce_platform.verify_total_path, params: params, headers: auth_headers
+        get solidus_paypal_commerce_platform.verify_total_path, params: params, headers: basic_auth_header
 
         expect(response).to have_http_status(200)
       end
@@ -30,7 +27,7 @@ RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request d
           format: :json
         }
 
-        get solidus_paypal_commerce_platform.verify_total_path, params: params, headers: auth_headers
+        get solidus_paypal_commerce_platform.verify_total_path, params: params, headers: basic_auth_header
 
         expect(response).to have_http_status(400)
       end

--- a/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request do
   stub_authorization!
   let(:order) { create(:order_with_line_items) }
+  let(:auth_headers) {
+    ENV['BASIC_AUTH'].present? ? { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(ENV['BASIC_AUTH'].split(':')[0], ENV['BASIC_AUTH'].split(':')[1]) } : {}
+  }
 
   describe "GET /solidus_paypal_commerce_platform/verify_total" do
     context "when the amount is correct" do
@@ -13,7 +16,7 @@ RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request d
           format: :json
         }
 
-        get solidus_paypal_commerce_platform.verify_total_path, params: params
+        get solidus_paypal_commerce_platform.verify_total_path, params: params, headers: auth_headers
 
         expect(response).to have_http_status(200)
       end
@@ -27,7 +30,7 @@ RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request d
           format: :json
         }
 
-        get solidus_paypal_commerce_platform.verify_total_path, params: params
+        get solidus_paypal_commerce_platform.verify_total_path, params: params, headers: auth_headers
 
         expect(response).to have_http_status(400)
       end

--- a/spec/requests/solidus_paypal_commerce_platform/shipping_rates_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/shipping_rates_controller_spec.rb
@@ -14,16 +14,13 @@ RSpec.describe SolidusPaypalCommercePlatform::ShippingRatesController, type: :re
       postal_code: new_address.zipcode
     }
   }
-  let(:auth_headers) {
-    ENV['BASIC_AUTH'].present? ? { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(ENV['BASIC_AUTH'].split(':')[0], ENV['BASIC_AUTH'].split(':')[1]) } : {}
-  }
 
   describe "GET /simulate_shipping_rates" do
     before do
       get solidus_paypal_commerce_platform.shipping_rates_path, params: {
         order_id: order.number,
         address: paypal_address
-      }, headers: auth_headers
+      }, headers: basic_auth_header
     end
 
     it "returns a paypal_order without the simulated address" do

--- a/spec/requests/solidus_paypal_commerce_platform/shipping_rates_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/shipping_rates_controller_spec.rb
@@ -14,13 +14,16 @@ RSpec.describe SolidusPaypalCommercePlatform::ShippingRatesController, type: :re
       postal_code: new_address.zipcode
     }
   }
+  let(:auth_headers) {
+    ENV['BASIC_AUTH'].present? ? { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(ENV['BASIC_AUTH'].split(':')[0], ENV['BASIC_AUTH'].split(':')[1]) } : {}
+  }
 
   describe "GET /simulate_shipping_rates" do
     before do
       get solidus_paypal_commerce_platform.shipping_rates_path, params: {
         order_id: order.number,
         address: paypal_address
-      }
+      }, headers: auth_headers
     end
 
     it "returns a paypal_order without the simulated address" do

--- a/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
 
   let(:wizard) { SolidusPaypalCommercePlatform::Wizard.new }
 
+  let(:auth_headers) {
+    ENV['BASIC_AUTH'].present? ? { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(ENV['BASIC_AUTH'].split(':')[0], ENV['BASIC_AUTH'].split(':')[1]) } : {}
+  }
+
   describe "POST /solidus_paypal_commerce_platform/wizard" do
     let(:params) {
       {
@@ -31,7 +35,7 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
       end.twice
 
       expect {
-        post solidus_paypal_commerce_platform.wizard_index_path, params: params
+        post solidus_paypal_commerce_platform.wizard_index_path, params: params, headers: auth_headers
       }.to change(SolidusPaypalCommercePlatform::PaymentMethod, :count).from(0).to(1)
 
       payment_method = SolidusPaypalCommercePlatform::PaymentMethod.last

--- a/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/wizard_controller_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
 
   let(:wizard) { SolidusPaypalCommercePlatform::Wizard.new }
 
-  let(:auth_headers) {
-    ENV['BASIC_AUTH'].present? ? { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(ENV['BASIC_AUTH'].split(':')[0], ENV['BASIC_AUTH'].split(':')[1]) } : {}
-  }
-
   describe "POST /solidus_paypal_commerce_platform/wizard" do
     let(:params) {
       {
@@ -35,7 +31,7 @@ RSpec.describe SolidusPaypalCommercePlatform::WizardController, type: :request d
       end.twice
 
       expect {
-        post solidus_paypal_commerce_platform.wizard_index_path, params: params, headers: auth_headers
+        post solidus_paypal_commerce_platform.wizard_index_path, params: params, headers: basic_auth_header
       }.to change(SolidusPaypalCommercePlatform::PaymentMethod, :count).from(0).to(1)
 
       payment_method = SolidusPaypalCommercePlatform::PaymentMethod.last

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,5 @@ RSpec.configure do |config|
   if Spree.solidus_gem_version < Gem::Version.new('2.11')
     config.extend Spree::TestingSupport::AuthorizationHelpers::Request, type: :system
   end
+  config.include AuthHelper
 end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,0 +1,22 @@
+module AuthHelper
+  def http_login_if_needed
+    return if ENV['BASIC_AUTH'].blank?
+
+    name, password = ENV['BASIC_AUTH'].split(':')
+    page.driver.browser.authorize(name, password)
+  end
+
+  def http_login_if_needed_js
+    return if ENV['BASIC_AUTH'].blank?
+
+    name, password = ENV['BASIC_AUTH'].split(':')
+    page.driver.basic_authorize(name, password)
+  end
+
+  def basic_auth_header
+    return {} if ENV['BASIC_AUTH'].blank?
+
+    name, password = ENV['BASIC_AUTH'].split(':')
+    { 'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(name, password) }
+  end
+end


### PR DESCRIPTION
This PR fixes Issue #103.

It does this by conditionally adding an authorization header in a beforeSend callback to the ajax requests in `button_actions.js`.

It also includes changes to conditionally enable basic auth middleware when `Rails.env == 'test'` and the BASIC_AUTH env variable are set, and updates the specs so that they still all pass from behind basic auth (for example when running `BASIC_AUTH=admin:password bundle exec rake extension:specs`).

This was a lot tricker than it seemed at first. In fact, there's another small issue in Solidus core that's related to a similar issue (specifically, and there could be other examples, running Solidus on staging behind basic auth breaks `/admin/taxonomies/:id/edit` with `Failed to load resource: the server responded with a status of 400 (Bad Request) /api/taxonomies/1?set=nested`). --- In other words, I'm definitely open to any suggestions on this PR and wondering if this same pattern would be the right way to deal with it in core.

