### PR TITLE
Add patch ability to update paypal order

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -199,3 +199,21 @@ SolidusPaypalCommercePlatform.updateAddress = function(response) {
     }
   })
 }
+
+SolidusPaypalCommercePlatform.updateOrder = function(payment_method_id) {
+  return Spree.ajax({
+    url: '/solidus_paypal_commerce_platform/paypal_orders/' + order_id,
+    method: 'PUT',
+    data: {
+      payment_method_id: payment_method_id,
+      order_token: order_token
+    },
+    success: function(response) {
+      return response;
+    },
+    error: function(response) {
+      message = response.responseJSON;
+      alert('A problem has occurred while updating your order - ' + message);
+    }
+  })
+}

--- a/app/controllers/solidus_paypal_commerce_platform/paypal_orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/paypal_orders_controller.rb
@@ -12,6 +12,13 @@ module SolidusPaypalCommercePlatform
       render json: order_request, status: order_request.status_code
     end
 
+    def update
+      authorize! :update, @order, order_token
+      order_request = @payment_method.gateway.update_order(@order, @payment_method.source)
+
+      render json: order_request, status: order_request.status_code
+    end
+
     private
 
     def load_payment_method

--- a/app/models/solidus_paypal_commerce_platform/gateway.rb
+++ b/app/models/solidus_paypal_commerce_platform/gateway.rb
@@ -80,6 +80,13 @@ module SolidusPaypalCommercePlatform
       @client.execute(request)
     end
 
+    def update_order(order, source)
+      request = OrdersPatchRequest.new(source.paypal_order_id)
+      paypal_order = SolidusPaypalCommercePlatform::PaypalOrder.new(order)
+      request.request_body [paypal_order.to_replace_json]
+      @client.execute(request)
+    end
+
     def get_order(order_id)
       @client.execute(OrdersGetRequest.new(order_id)).result
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 SolidusPaypalCommercePlatform::Engine.routes.draw do
   # Add your extension routes here
   resources :wizard, only: [:create]
-  resources :paypal_orders, only: [:show], param: :order_id
+  resources :paypal_orders, only: [:show, :update], param: :order_id
   resources :orders, only: [:create]
   resources :payments, only: [:create]
   get :shipping_rates, to: "shipping_rates#simulate_shipping_rates"

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -15,9 +15,17 @@ module SolidusPaypalCommercePlatform
     engine_name 'solidus_paypal_commerce_platform'
 
     initializer "solidus_paypal_commerce_platform.add_payment_method", after: "spree.register.payment_methods" do |app|
-      app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod
-      SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
-      Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id, :paypal_email]
+      app.config.to_prepare do
+        app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod
+
+        unless SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types.include?(:paypal_select)
+          SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
+        end
+
+        old_source_attributes = ::Spree::PermittedAttributes.source_attributes
+        new_source_attributes = [:paypal_order_id, :authorization_id, :paypal_email, :paypal_funding_source]
+        ::Spree::PermittedAttributes.source_attributes.concat(new_source_attributes - old_source_attributes)
+      end
     end
 
     initializer "solidus_paypal_commerce_platform.add_wizard", after: "spree.register.payment_methods" do |app|

--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_paypal_commerce_platform'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/releases'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/requests/solidus_paypal_commerce_platform/paypal_orders_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/paypal_orders_controller_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPaypalCommercePlatform::PaypalOrdersController, type: :request do
+  stub_authorization!
+  let(:order) { create(:order_with_line_items) }
+  let(:paypal_order_id) { SecureRandom.uuid }
+  let(:capture_id) { SecureRandom.uuid }
+  let(:refund_id) { SecureRandom.uuid }
+  let(:paypal_payment_method) { create(:paypal_payment_method) }
+  let(:payment_source) do
+    SolidusPaypalCommercePlatform::PaymentSource.new(
+      paypal_order_id: paypal_order_id,
+      capture_id: capture_id,
+      refund_id: refund_id,
+      payment_method: create(:paypal_payment_method)
+    )
+  end
+  let(:payment) do
+    order.payments.create!(
+      payment_method: payment_source.payment_method,
+      source: payment_source,
+    )
+  end
+  let(:response) do
+    Struct(
+      result: nil,
+      headers: {},
+      status_code: 200
+    )
+  end
+  let(:error_response) do
+    Struct(
+      result: nil,
+      headers: {},
+      status_code: 401
+    )
+  end
+
+  def Struct(data) # rubocop:disable Naming/MethodName
+    Struct.new(*data.keys, keyword_init: true).new(data)
+  end
+
+  describe 'GET /solidus_paypal_commerce_platform/paypal_orders' do
+    context 'when is correct' do
+      before do
+        allow_any_instance_of(PayPal::PayPalHttpClient)
+          .to receive(:execute) { response }
+        allow_any_instance_of(SolidusPaypalCommercePlatform::Client)
+          .to receive(:execute) { response }
+      end
+
+      it 'passes' do
+        get "/solidus_paypal_commerce_platform/paypal_orders/#{order.number}"
+
+        expect(response.status_code).to be(200)
+      end
+    end
+
+    context 'when is incorrect' do
+      before do
+        allow_any_instance_of(PayPal::PayPalHttpClient)
+          .to receive(:execute) { error_response }
+        allow_any_instance_of(SolidusPaypalCommercePlatform::Client)
+          .to receive(:execute) { error_response }
+      end
+
+      it 'fails' do
+        get "/solidus_paypal_commerce_platform/paypal_orders/#{order.number}"
+
+        expect(error_response.status_code).to be(401)
+      end
+    end
+  end
+
+  describe 'PUT /solidus_paypal_commerce_platform/paypal_orders' do
+    context 'when is correct' do
+      before do
+        allow_any_instance_of(PayPal::PayPalHttpClient)
+          .to receive(:execute) { response }
+        allow_any_instance_of(SolidusPaypalCommercePlatform::Client)
+          .to receive(:execute) { response }
+      end
+
+      it 'passes' do
+        params = {
+          payment_method_id: payment.payment_method.id,
+          format: :json
+        }
+
+        put "/solidus_paypal_commerce_platform/paypal_orders/#{order.number}",
+            params: params
+
+        expect(response.status_code).to be(200)
+      end
+    end
+
+    context 'when is incorrect' do
+      before do
+        allow_any_instance_of(PayPal::PayPalHttpClient)
+          .to receive(:execute) { error_response }
+        allow_any_instance_of(SolidusPaypalCommercePlatform::Client)
+          .to receive(:execute) { error_response }
+      end
+
+      it 'fails' do
+        params = {
+          payment_method_id: payment.payment_method.id,
+          format: :json
+        }
+
+        put "/solidus_paypal_commerce_platform/paypal_orders/#{order.number}",
+            params: params
+
+        expect(error_response.status_code).to be(401)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on https://github.com/paypal/Checkout-Ruby-SDK/blob/685b0637404f3f38cfb5234d294293c294f175de/lib/orders/orders_patch_request.rb we are able to use `PATCH` to update Paypal Order information