### PR TITLE
Move 'shipping_preference' preference under PaypalOrder#to_json

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -181,8 +181,11 @@ SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_metho
   })
 }
 
-SolidusPaypalCommercePlatform.updateAddress = function(response) { 
-  var updated_address = response.purchase_units[0].shipping.address
+SolidusPaypalCommercePlatform.updateAddress = function(response) {
+  var shipping = response.purchase_units[0].shipping;
+  if (!shipping) return Promise.resolve({});
+
+  var updated_address = shipping.address;
   return Spree.ajax({
     url: '/solidus_paypal_commerce_platform/update_address',
     method: 'POST',

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -87,7 +87,6 @@ module SolidusPaypalCommercePlatform
         currency: currency
       }
 
-      parameters[:shipping_preference] = 'NO_SHIPPING' if step_names.exclude? 'delivery'
       parameters['enable-funding'] = 'venmo' if venmo_standalone_enabled?
 
       if !Rails.env.production? && options[:force_buyer_country].present?

--- a/app/models/solidus_paypal_commerce_platform/paypal_order.rb
+++ b/app/models/solidus_paypal_commerce_platform/paypal_order.rb
@@ -10,7 +10,8 @@ module SolidusPaypalCommercePlatform
       {
         intent: intent,
         purchase_units: purchase_units,
-        payer: (payer if @order.bill_address)
+        payer: (payer if @order.bill_address),
+        application_context: application_context
       }
     end
 
@@ -108,6 +109,18 @@ module SolidusPaypalCommercePlatform
         currency_code: @order.currency,
         value: amount
       }
+    end
+
+    def application_context
+      {
+        shipping_preference: require_shipping? ? 'SET_PROVIDED_ADDRESS' : 'NO_SHIPPING'
+      }
+    end
+
+    def require_shipping?
+      step_names = @order ? @order.checkout_steps : ::Spree::Order.checkout_steps.keys
+
+      step_names.include? 'delivery'
     end
   end
 end

--- a/app/models/solidus_paypal_commerce_platform/paypal_order.rb
+++ b/app/models/solidus_paypal_commerce_platform/paypal_order.rb
@@ -118,9 +118,11 @@ module SolidusPaypalCommercePlatform
     end
 
     def require_shipping?
-      step_names = @order ? @order.checkout_steps : ::Spree::Order.checkout_steps.keys
+      step_names.include? :delivery
+    end
 
-      step_names.include? 'delivery'
+    def step_names
+      @order ? @order.checkout_steps.map(&:to_sym) : ::Spree::Order.checkout_steps.keys
     end
   end
 end

--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -127,13 +127,6 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
       end
     end
 
-    context 'when checkout_steps does not include "delivery"' do
-      it 'disables autocommit' do
-        allow(order).to receive(:checkout_steps).and_return([:address, :confirm, :payment])
-        expect(url.query.split("&")).to include("shipping_preference=NO_SHIPPING")
-      end
-    end
-
     context 'when messaging is turned on' do
       it 'includes messaging component' do
         paypal_payment_method.preferences.update(display_credit_messaging: true)

--- a/spec/models/solidus_paypal_commerce_platform/paypal_order_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/paypal_order_spec.rb
@@ -22,7 +22,19 @@ RSpec.describe SolidusPaypalCommercePlatform::PaypalOrder, type: :model do
     end
 
     context 'when checkout_steps does not include "delivery"' do
-      let(:order) { instance_double(Spree::Order, checkout_steps: { "foo" => "bar" }) }
+      let(:old_checkout_flow) { Spree::Order.checkout_flow }
+
+      before do
+        old_checkout_flow
+
+        Spree::Order.class_eval do
+          remove_checkout_step :delivery
+        end
+      end
+
+      after do
+        Spree::Order.checkout_flow(&old_checkout_flow)
+      end
 
       it 'disable shipping requirements' do
         expect(to_json).to match hash_including(

--- a/spec/models/solidus_paypal_commerce_platform/paypal_order_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/paypal_order_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe SolidusPaypalCommercePlatform::PaypalOrder, type: :model do
         payer: hash_including(name: { given_name: 'Johnny', surname: 'Vonny Doey' })
       )
     end
+
+    context 'when checkout_steps does not include "delivery"' do
+      let(:order) { instance_double(Spree::Order, checkout_steps: { "foo" => "bar" }) }
+
+      it 'disable shipping requirements' do
+        expect(to_json).to match hash_including(
+          application_context: hash_including(shipping_preference: 'NO_SHIPPING')
+        )
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Fix #133 shipping_preference with 'NO_SHIPPING' is now provided under PaypalOrder#to_json, otherwise 'SET_PROVIDED_ADDRESS'