### PR TITLE
Fix paypal_order name address bug

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/paypal_order.rb
+++ b/app/models/solidus_paypal_commerce_platform/paypal_order.rb
@@ -45,7 +45,7 @@ module SolidusPaypalCommercePlatform
 
     def name(address)
       if greater_than_2_10?
-        name = ::Spree::Address::Name.new @order.ship_address.name
+        name = ::Spree::Address::Name.new address.name
 
         {
           given_name: name.first_name,

--- a/spec/models/solidus_paypal_commerce_platform/paypal_order_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/paypal_order_spec.rb
@@ -6,28 +6,29 @@ RSpec.describe SolidusPaypalCommercePlatform::PaypalOrder, type: :model do
   describe '#to_json' do
     subject(:to_json) { described_class.new(order).to_json('intent') }
 
-    let(:order) { create(:order_ready_to_complete) }
+    let(:order) { create(:order_ready_to_complete, ship_address: ship_address, bill_address: bill_address) }
+    let(:ship_address) { create_address('John', 'Von Doe') }
+    let(:bill_address) { create_address('Johnny', 'Vonny Doey') }
 
     it { expect { to_json }.not_to raise_error }
 
+    it 'maps the bill and ship address names correctly' do
+      expect(to_json).to match hash_including(
+        purchase_units: array_including(
+          hash_including(shipping: hash_including(name: { full_name: 'John Von Doe' }))
+        ),
+        payer: hash_including(name: { given_name: 'Johnny', surname: 'Vonny Doey' })
+      )
+    end
+  end
+
+  private
+
+  def create_address(firstname, lastname)
     if Spree.solidus_gem_version >= Gem::Version.new('2.11')
-      it 'returns the name of the user' do
-        expect(to_json).to match hash_including(
-          purchase_units: array_including(
-            hash_including(shipping: hash_including(name: { full_name: 'John Von Doe' }))
-          ),
-          payer: hash_including(name: { given_name: 'John', surname: 'Von Doe' })
-        )
-      end
+      create(:address, name: "#{firstname} #{lastname}")
     else
-      it 'returns the name and surname of the user' do
-        expect(to_json).to match hash_including(
-          purchase_units: array_including(
-            hash_including(shipping: hash_including(name: { full_name: 'John' }))
-          ),
-          payer: hash_including(name: { given_name: 'John', surname: nil })
-        )
-      end
+      create(:address, firstname: firstname, lastname: lastname)
     end
   end
 end


### PR DESCRIPTION
On the following line, the billing address is given to the name method.
https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/blob/64be7ddb4967a93155c035430101d4bbfce83313/app/models/solidus_paypal_commerce_platform/paypal_order.rb#L40

The following commit accidentally started using the order's
ship_address instead of the given billing address when Solidus' version
is >= 2.11.
https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/commit/63fe8f9702dbd282d7ddcdc91f41d6fb48f238c4

Reference:
https://github.com/solidusio-contrib/solidus_paypal_commerce_platform/pull/122#issuecomment-983572478