### PR TITLE
Remove solidus prefix from component names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ commands:
       - browser-tools/install-chrome
       - run:
           name: Install libvips
-          command: sudo apt-get install -y libvips
+          command: |
+            sudo apt-get update
+            sudo apt-get install -yq libvips-dev
       - solidusio_extensions/test-branch:
           branch: master
           command: |

--- a/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
+++ b/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
@@ -18,7 +18,7 @@ module SolidusPaypalCommercePlatform
       end
 
       def install_solidus_backend_support
-        support_code_for(:solidus_backend) do
+        support_code_for(:backend) do
           append_file(
             'vendor/assets/javascripts/spree/backend/all.js',
             "//= require spree/backend/solidus_paypal_commerce_platform\n"
@@ -33,7 +33,7 @@ module SolidusPaypalCommercePlatform
       end
 
       def install_solidus_starter_frontend_support
-        support_code_for(:solidus_starter_frontend) do
+        support_code_for(:starter_frontend) do
           directory 'app', 'app'
           append_file(
             'app/assets/javascripts/solidus_starter_frontend.js',


### PR DESCRIPTION
## Summary 

The component_name arguments passed to `support_code_for` must match the class options of the generator.

Fixes #172.

## Test app

See the Rails app in https://github.com/gsmendoza/solidus_store/tree/rails-7-0-4--solidus-3-2-4--solidus-paypal-commerce-platform. Its solidus_paypal_commerce_platform gem has been updated to point to this branch.

## Screenshots

![image](https://user-images.githubusercontent.com/61476/206394800-c96b9bb4-3dd7-42a7-bcc3-b72efe5608b3.png)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
