### PR TITLE
Fix: preferred_paypal_button_color error message should be translated dynamically

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -17,7 +17,9 @@ module SolidusPaypalCommercePlatform
 
     validates :preferred_paypal_button_color, exclusion: {
       in: %w[gold],
-      message: I18n.t("solidus_paypal_commerce_platform.payment_method.gold_button_message")
+      message: ->(_object, _data) do
+        I18n.t("solidus_paypal_commerce_platform.payment_method.gold_button_message")
+      end
     }, if: :venmo_standalone_enabled?
 
     def venmo_standalone_enabled?

--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -24,8 +24,12 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
 
       it 'cannot be gold when Venmo standalone is enabled' do
         expect(paypal_payment_method).to be_valid
+
         paypal_payment_method.preferences.update(venmo_standalone: 'enabled')
         expect(paypal_payment_method).to be_invalid
+        expect(paypal_payment_method.errors[:preferred_paypal_button_color])
+          .to include(I18n.t("solidus_paypal_commerce_platform.payment_method.gold_button_message"))
+
         paypal_payment_method.preferences.update(venmo_standalone: 'only render standalone')
         expect(paypal_payment_method).to be_invalid
       end


### PR DESCRIPTION
Otherwise, the message would be translated when
`SolidusPaypalCommercePlatform::PaymentMethod` is loaded, during which time the
locales may not have been loaded yet.

Fixes #178.

See Proc message example at
https://guides.rubyonrails.org/active_record_validations.html#message.

## Screenshot

![image](https://user-images.githubusercontent.com/61476/208641580-b8332a5b-d280-434b-9dda-515b29131918.png)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
