### PR TITLE
Allow cancelling orders

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -97,5 +97,22 @@ module SolidusPaypalCommercePlatform
 
       "https://www.paypal.com/sdk/js?#{parameters.compact.to_query}".html_safe # rubocop:disable Rails/OutputSafety
     end
+
+    # Will void the payment depending on its state or return false
+    #
+    # If the payment has not yet been captured, we can void the transaction.
+    # Otherwise, we return false so Solidus creates a refund instead.
+    #
+    # https://developer.paypal.com/docs/api/payments/v2/#authorizations_void
+    #
+    # @api public
+    # @param payment [Spree::Payment] the payment to void
+    # @return [Response|FalseClass]
+    def try_void(payment)
+      void_attempt = void(nil, { originator: payment })
+      return void_attempt if void_attempt.success?
+
+      false
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
         success: "Payment refunded for %{amount}"
       pay_pal_checkout_sdk/payments/authorizations_void_request:
         success: "Payment voided"
+        failure: "This payment can't be voided"
     payment_method:
       gold_button_message: "cannot be 'gold' when Venmo standalone is enabled."
     paypal_funding_sources:

--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -96,6 +96,32 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
     end
   end
 
+  describe "#try_void" do
+    context "when the payment is already captured" do
+      let(:status_code) { 500 }
+
+      it "returns false" do
+        authorization_id = SecureRandom.hex(8)
+        source = paypal_payment_method.payment_source_class.create(authorization_id: authorization_id)
+        payment.source = source
+
+        expect(paypal_payment_method.try_void(payment)).to be_falsey
+      end
+    end
+
+    context "when the payment is not yet captured" do
+      let(:status_code) { 204 }
+
+      it "returns the success response" do
+        authorization_id = SecureRandom.hex(8)
+        source = paypal_payment_method.payment_source_class.create(authorization_id: authorization_id)
+        payment.source = source
+
+        expect(paypal_payment_method.try_void(payment)).to be_success
+      end
+    end
+  end
+
   describe "#credit" do
     let(:result) { Struct(id: SecureRandom.hex(4)) }
 


### PR DESCRIPTION
Fixes #120 

🚨 We need to backport this on main/master + release new versions (see #182)

## Summary

Implementing `#try_void` on the PayPal payment method, we can now cancel orders from the admin panel.

With try_void ready, Solidus will try to void the payment, if it's too late and the order is already captured, it will immediately issue a refund, otherwise it will just void the payment.


## Test

I've made two orders locally and canceled them. 

The first one was not captured, and it's correctly voided:

<img width="1228" alt="Screenshot 2022-12-30 at 14 40 20@2x" src="https://user-images.githubusercontent.com/167946/210076366-2e11f0cb-8435-4ae0-9308-e97713655db1.png">

The second one was captured and it's correctly cancelled + refund issued:

<img width="1204" alt="Screenshot 2022-12-30 at 14 42 07@2x" src="https://user-images.githubusercontent.com/167946/210076432-4d900dd3-6855-4a38-920d-8e5e8f212e46.png">


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
