### PR TITLE
Do not break custom pricing options classes

### DIFF
--- a/app/decorators/models/solidus_paypal_commerce_platform/spree/variant/pricing_options_decorator.rb
+++ b/app/decorators/models/solidus_paypal_commerce_platform/spree/variant/pricing_options_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SolidusPaypalCommercePlatform
+  module Spree
+    module Variant
+      module PricingOptionsDecorator
+        def cache_key
+          SolidusPaypalCommercePlatform::PaymentMethod.
+            active.
+            map(&:cache_key_with_version).
+            sort + [super]
+        end
+
+        ::Spree::Variant::PricingOptions.prepend self
+      end
+    end
+  end
+end

--- a/app/models/solidus_paypal_commerce_platform/pricing_options.rb
+++ b/app/models/solidus_paypal_commerce_platform/pricing_options.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module SolidusPaypalCommercePlatform
-  class PricingOptions < ::Spree::Variant::PricingOptions
-    def cache_key
-      SolidusPaypalCommercePlatform::PaymentMethod.active.map(&:cache_key_with_version).sort + [super]
-    end
-  end
-end

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -34,12 +34,6 @@ module SolidusPaypalCommercePlatform
       app.config.spree.payment_setup_wizards << "SolidusPaypalCommercePlatform::Wizard"
     end
 
-    initializer "solidus_paypal_commerce_platform.set_pricing_options_class" do
-      def (Spree::Config).pricing_options_class
-        SolidusPaypalCommercePlatform::PricingOptions
-      end
-    end
-
     initializer "solidus_paypal_commerce_platform.webhooks" do
       SolidusWebhooks.config.register_webhook_handler :solidus_paypal_commerce_platform, ->(payload) {
         SolidusPaypalCommercePlatform::WebhooksJob.perform_now(payload)


### PR DESCRIPTION
## Summary

Prior to this commit, installing this gem would break custom pricing options classes in host apps: By overriding the getter on `Spree::Config`, it was very difficult to use a custom pricing options class. By instead decorating the base class, we make sure that even if host app developers have used their own pricing options class, that pricing options class gets the right `cache_key` method (provided they themselves overrode `cache_key` using `super`).


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
