### PR TITLE
Uniform installer with Solidus Starter Frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ gem 'solidus_paypal_commerce_platform'
 Bundle your dependencies and run the installation generator:
 
 ```shell
+bundle install
+bin/rails generate solidus_paypal_commerce_platform:install
+```
+
+### Compatibility with solidus_frontend (deprecated)
+
+Support for the old frontend is terminated but if you are using the
+`solidus_frontend` gem instead of Solidus Starter Frontend, you can
+still use this gem for some time. Please, use `0.x` version.
+
+```ruby
+gem 'solidus_paypal_commerce_platform', '< 1'
+```
+
+Bundle your dependencies and run the installation generator:
+
+```shell
+bundle install
 bin/rails generate solidus_paypal_commerce_platform:install
 ```
 

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -52,7 +52,7 @@ unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-mast
 unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --payment-method=none --auto-accept "$@"
 unbundled bundle add ${extension_name} --path '../'
-unbundled bundle exec rails generate ${extension_name}:install --starter-frontend=true --migrate=true
+unbundled bundle exec rails generate ${extension_name}:install --frontend=starter --migrate=true
 
 echo
 echo "🚀 Sandbox app successfully created for ${extension_name}!"

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -50,10 +50,12 @@ fi
 cd ./sandbox
 unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-master}" --version '> 0.a'
 unbundled bundle exec rake db:drop db:create
-unbundled bundle exec rails generate solidus:install --auto-accept "$@"
+unbundled bundle exec rails generate solidus:install --payment-method=none --auto-accept "$@"
+unbundled bundle add ${extension_name} --path '../'
+unbundled bundle exec rails generate ${extension_name}:install --starter-frontend=true --migrate=true
 
 echo
-echo "🚀 Sandbox app successfully created for $extension_name!"
+echo "🚀 Sandbox app successfully created for ${extension_name}!"
 echo "🚀 Using $RAILSDB and Solidus $BRANCH"
 echo "🚀 Use 'export DB=[postgres|mysql|sqlite]' to control the DB adapter"
 echo "🚀 Use 'export SOLIDUS_BRANCH=<BRANCH-NAME>' to control the Solidus version"

--- a/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
+++ b/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
@@ -5,13 +5,20 @@ module SolidusPaypalCommercePlatform
     class InstallGenerator < Rails::Generators::Base
       class_option :migrate, type: :boolean, default: true
       class_option :backend, type: :boolean, default: true
-      class_option :starter_frontend, type: :boolean, default: true
+      class_option :frontend, type: :string, default: 'starter'
 
       # This is only used to run all-specs during development and CI,  regular installation limits
       # installed specs to frontend, which are the ones related to code copied to the target application.
       class_option :specs, type: :string, enum: %w[all frontend], default: 'frontend', hide: true
 
       source_root File.expand_path('templates', __dir__)
+
+      def normalize_components_options
+        @components = {
+          backend: options[:backend],
+          starter_frontend: options[:frontend] == 'starter',
+        }
+      end
 
       def install_solidus_core_support
         directory 'config/initializers', 'config/initializers'
@@ -73,7 +80,7 @@ module SolidusPaypalCommercePlatform
       private
 
       def support_code_for(component_name, &block)
-        if options[component_name]
+        if @components[component_name]
           say_status :install, "[#{engine.engine_name}] solidus_#{component_name}", :blue
           shell.indent(&block)
         else

--- a/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
+++ b/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
@@ -17,6 +17,7 @@ module SolidusPaypalCommercePlatform
         @components = {
           backend: options[:backend],
           starter_frontend: options[:frontend] == 'starter',
+          classic_frontend: options[:frontend] == 'classic',
         }
       end
 
@@ -74,6 +75,17 @@ module SolidusPaypalCommercePlatform
               template engine.root.join(path), path
             end
           end
+        end
+      end
+
+      def alert_no_classic_frontend_support
+        support_code_for(:classic_frontend) do
+          message = <<~TEXT
+            For solidus_frontend compatibility, please use the deprecated version 0.x.
+            The new version of this extension only supports Solidus Starter Frontend.
+            No frontend code has been copied to your application.
+          TEXT
+          say_status :error, set_color(message.tr("\n", ' '), :red), :red
         end
       end
 


### PR DESCRIPTION
## Summary

Solidus installer uses the `--frontend=starter/classic` format to choose which frontend to install. This is an attempt to try to use the same format to be uniform and provide some predictability to our users. 

The installer code is a bit more complex, though. 


For some context, this comes from me trying to do something similar in https://github.com/solidusio/solidus_subscriptions/pull/276: as pointed out, we might try to create a standard, uniform way of solving this problem.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [ ] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
