### PR TITLE
[v1] Allow to use the auto_capture global preference

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -85,7 +85,7 @@ module SolidusPaypalCommercePlatform
 
       parameters = {
         'client-id': client_id,
-        intent: auto_capture ? "capture" : "authorize",
+        intent: auto_capture? ? "capture" : "authorize",
         commit: commit_immediately ? "false" : "true",
         components: options[:display_credit_messaging] ? "buttons,messages" : "buttons",
         currency: currency,

--- a/lib/generators/solidus_paypal_commerce_platform/install/templates/app/controllers/solidus_paypal_commerce_platform/paypal_orders_controller.rb
+++ b/lib/generators/solidus_paypal_commerce_platform/install/templates/app/controllers/solidus_paypal_commerce_platform/paypal_orders_controller.rb
@@ -7,7 +7,7 @@ module SolidusPaypalCommercePlatform
 
     def show
       authorize! :show, @order, order_token
-      order_request = @payment_method.gateway.create_order(@order, @payment_method.auto_capture)
+      order_request = @payment_method.gateway.create_order(@order, @payment_method.auto_capture?)
 
       render json: order_request, status: order_request.status_code
     end

--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -157,6 +157,31 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
       end
     end
 
+    context 'when autocapture value is true' do
+      it 'sets the intent to capture' do
+        paypal_payment_method.update(auto_capture: true)
+
+        expect(url.query.split("&")).to include("intent=capture")
+      end
+    end
+
+    context 'when autocapture value is false' do
+      it 'sets the intent to capture' do
+        paypal_payment_method.update(auto_capture: false)
+
+        expect(url.query.split("&")).to include("intent=authorize")
+      end
+    end
+
+    context 'when autocapture value is nil' do
+      it 'sets the intent to the global auto_capture value' do
+        paypal_payment_method.update(auto_capture: nil)
+        stub_spree_preferences(auto_capture: true)
+
+        expect(url.query.split("&")).to include("intent=capture")
+      end
+    end
+
     context 'when messaging is turned on' do
       it 'includes messaging component' do
         paypal_payment_method.preferences.update(display_credit_messaging: true)


### PR DESCRIPTION
Porting of #185 into v1

## Summary

In the Payment Method edit UI, we can choose the autocapture preference we want to be applied for their payments.

The choices are: "Yes", "No", "Use App Default".

When the last option is picked, the value for this boolean is set to nil and we were not considering this last option through the codebase.

Luckily, a [convenient method](https://github.com/solidusio/solidus/blob/929035c957f75ebd7ae745af69bf2a93a3727a87/core/app/models/spree/payment_method.rb#L156-L158) in Solidus allows us to return the App Default value.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [ ] I have attached screenshots to demo visual changes.
- [ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [ ] I have updated the README to account for my changes.
