### PR TITLE
Fix dummy and sandbox generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
           command: |
             export FRONTEND=starter
             sudo gem update --system
-            gem install bundler
+            gem install bundler rails
             bin/dummy-app
             bin/rspec
       - solidusio_extensions/store-test-results

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -14,14 +14,14 @@ function unbundled {
 test "$DB" = "sqlite" && export DB="sqlite3"
 
 rm -rf ./dummy-app
-unbundled bundle exec rails new dummy-app \
+rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
+rails _${rails_version}_ new dummy-app \
   --database=${DB:-sqlite3} \
-  --skip-bundle \
   --skip-git \
   --skip-keeps \
   --skip-rc \
-  --skip-spring \
-  --skip-javascript
+  --skip-bootsnap \
+  --skip-test
 
 if [ ! -d "dummy-app" ]; then
   echo 'dummy-app rails application failed'

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -14,8 +14,7 @@ function unbundled {
 test "$DB" = "sqlite" && export DB="sqlite3"
 
 rm -rf ./dummy-app
-rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
-rails _${rails_version}_ new dummy-app \
+rails new dummy-app \
   --database=${DB:-sqlite3} \
   --skip-git \
   --skip-keeps \

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -33,14 +33,15 @@ function unbundled {
 }
 
 rm -rf ./sandbox
-unbundled bundle exec rails new sandbox --database="$RAILSDB" \
+rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
+rails _${rails_version}_ new sandbox \
+  --database="$RAILSDB" \
   --skip-bundle \
   --skip-git \
   --skip-keeps \
   --skip-rc \
-  --skip-spring \
-  --skip-test \
-  --skip-javascript
+  --skip-bootsnap \
+  --skip-test
 
 if [ ! -d "sandbox" ]; then
   echo 'sandbox rails application failed'

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -33,8 +33,7 @@ function unbundled {
 }
 
 rm -rf ./sandbox
-rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
-rails _${rails_version}_ new sandbox \
+rails new sandbox \
   --database="$RAILSDB" \
   --skip-bundle \
   --skip-git \


### PR DESCRIPTION
## Summary

This change fixes two issues:

1. Now that we need importmap/stimulus/turbo running in the storefront application, we also need to generate the dummy and sandbox apps with that stack installed. [The --skip-bundle option prevents those options from being installed][1], so we need to run them manually. ~I tried to remove the `--skip-bundle` instead, but there are a lot of errors, apparently related to having the app containing some files that won't work before solidus is installed.~ See PR's comments below. 👇 
2. [`--skip-spring` has been replaced by `--skip-bootsnap` in Rails][2]

[1]: https://github.com/rails/rails/blob/9fcfbe5306cf632f5f47fa8bb5dfa36545ab1be6/railties/lib/rails/generators/app_base.rb#L448-L461
[2]: https://github.com/rails/rails/blob/9fcfbe5306cf632f5f47fa8bb5dfa36545ab1be6/railties/lib/rails/generators/app_base.rb#L81


## Additional notes

We could try to remove `--skip-bundle` instead, but I'm still not sure it's possible. @elia do you remember why it was needed?




<details>
  <summary>For reference, this is the stacktrace removing it</summary>

```
Creating the dummy-app app...
      create
      create  README.md
      create  Rakefile
      create  .ruby-version
      create  config.ru
      create  Gemfile
      create  app
      create  app/assets/config/manifest.js
      create  app/assets/stylesheets/application.css
      create  app/channels/application_cable/channel.rb
      create  app/channels/application_cable/connection.rb
      create  app/controllers/application_controller.rb
      create  app/helpers/application_helper.rb
      create  app/jobs/application_job.rb
      create  app/mailers/application_mailer.rb
      create  app/models/application_record.rb
      create  app/views/layouts/application.html.erb
      create  app/views/layouts/mailer.html.erb
      create  app/views/layouts/mailer.text.erb
      create  app/assets/images
      create  bin
      create  bin/rails
      create  bin/rake
      create  bin/setup
      create  config
      create  config/routes.rb
      create  config/application.rb
      create  config/environment.rb
      create  config/cable.yml
      create  config/puma.rb
      create  config/storage.yml
      create  config/environments
      create  config/environments/development.rb
      create  config/environments/production.rb
      create  config/environments/test.rb
      create  config/initializers
      create  config/initializers/assets.rb
      create  config/initializers/content_security_policy.rb
      create  config/initializers/cors.rb
      create  config/initializers/filter_parameter_logging.rb
      create  config/initializers/inflections.rb
      create  config/initializers/new_framework_defaults_7_0.rb
      create  config/initializers/permissions_policy.rb
      create  config/locales
      create  config/locales/en.yml
      create  config/master.key
      create  config/boot.rb
      create  config/database.yml
      create  db
      create  db/seeds.rb
      create  lib
      create  lib/tasks
      create  lib/assets
      create  log
      create  public
      create  public/404.html
      create  public/422.html
      create  public/500.html
      create  public/apple-touch-icon-precomposed.png
      create  public/apple-touch-icon.png
      create  public/favicon.ico
      create  public/robots.txt
      create  tmp
      create  tmp/pids
      create  tmp/cache
      create  tmp/cache/assets
      create  vendor
      create  storage
      create  tmp/storage
      remove  config/initializers/cors.rb
      remove  config/initializers/new_framework_defaults_7_0.rb
         run  bundle install
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Using rake 13.0.6
Using rack 2.2.6.2
Using nio4r 2.5.8
Using minitest 5.17.0
Using timeout 0.3.1
Using bundler 2.3.23
Using racc 1.6.2
Using crass 1.0.6
Using websocket-extensions 0.1.5
Using marcel 1.0.2
Using mini_mime 1.1.2
Using concurrent-ruby 1.2.0
Using date 3.3.3
Using builder 3.2.4
Using net-protocol 0.2.1
Using erubi 1.12.0
Using io-console 0.6.0
Using i18n 1.12.0
Using method_source 1.0.0
Using sprockets 4.2.0
Using zeitwerk 2.6.6
Using rack-test 2.0.2
Using puma 5.6.5
Using reline 0.3.2
Using nokogiri 1.14.1 (arm64-darwin)
Using websocket-driver 0.7.5
Using tzinfo 2.0.6
Using thor 1.2.1
Using bindex 0.8.1
Using net-imap 0.3.4
Using net-pop 0.1.2
Using net-smtp 0.3.3
Using sqlite3 1.6.0 (arm64-darwin)
Using loofah 2.19.1
Using mail 2.8.1
Using irb 1.6.2
Using activesupport 7.0.4.2
Using rails-html-sanitizer 1.5.0
Using rails-dom-testing 2.0.3
Using globalid 1.1.0
Using activemodel 7.0.4.2
Using debug 1.7.1
Using activerecord 7.0.4.2
Using actionview 7.0.4.2
Using activejob 7.0.4.2
Using actionpack 7.0.4.2
Using jbuilder 2.11.5
Using actioncable 7.0.4.2
Using activestorage 7.0.4.2
Using actionmailer 7.0.4.2
Using railties 7.0.4.2
Using actionmailbox 7.0.4.2
Using actiontext 7.0.4.2
Using importmap-rails 1.1.5
Using stimulus-rails 1.2.1
Using turbo-rails 1.3.3
Using rails 7.0.4.2
Using web-console 4.2.0
Using sprockets-rails 3.4.2
Bundle complete! 11 Gemfile dependencies, 59 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
         run  bundle binstubs bundler
       rails  importmap:install
rails aborted!
LoadError: cannot load such file -- active_storage/engine
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/config/application.rb:8:in `require'
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/config/application.rb:8:in `<top (required)>'
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/Rakefile:4:in `require_relative'
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/Rakefile:4:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
(See full trace by running task with --trace)
       rails  turbo:install stimulus:install
rails aborted!
LoadError: cannot load such file -- active_storage/engine
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/config/application.rb:8:in `require'
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/config/application.rb:8:in `<top (required)>'
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/Rakefile:4:in `require_relative'
/Users/kennyadsl/Code/solidusio-contrib/solidus_paypal_commerce_platform/dummy-app/Rakefile:4:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
(See full trace by running task with --trace)
Fetching https://github.com/solidusio/solidus.git
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...

# ... the rest is identical to a succeeding installation
```
</details>

Please note that despite these errors, the installation reaches the finish line but it's corrupted because the hotwire stack is not installed. 


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
