### PR TITLE
Fix migration version

### DIFF
--- a/db/migrate/20211220133406_add_paypal_funding_source_to_paypal_commerce_platform_sources.rb
+++ b/db/migrate/20211220133406_add_paypal_funding_source_to_paypal_commerce_platform_sources.rb
@@ -1,4 +1,4 @@
-class AddPaypalFundingSourceToPaypalCommercePlatformSources < ActiveRecord::Migration[6.1]
+class AddPaypalFundingSourceToPaypalCommercePlatformSources < ActiveRecord::Migration[5.2]
   def change
     add_column :paypal_commerce_platform_sources, :paypal_funding_source, :integer
   end


### PR DESCRIPTION
We still support Rails 5.2 with this gem, because we allow Solidus 3.0, which in return still allows Rails 5.2. Installing this extension during a dummy app install in another extension fails, if the dummy app still is a Rails 6.0 app.
