### PR TITLE
Adapt to latest Solidus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,14 @@ jobs:
   run-specs-with-mysql:
     executor:
       name: solidusio_extensions/mysql
-      ruby_version: '3.0'
+      ruby_version: '3.1'
     steps:
       - test-with-starter-frontend
 
   run-specs-with-sqlite:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: '2.7'
+      ruby_version: '3.0'
     steps:
       - test-with-starter-frontend
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
             sudo apt-get update
             sudo apt-get install -yq libvips-dev
       - solidusio_extensions/test-branch:
-          branch: master
+          branch: main
           command: |
             export FRONTEND=starter
             sudo gem update --system
@@ -64,14 +64,14 @@ workflows:
       - run-specs-with-sqlite
       - lint-code
 
-  "Weekly run specs against master":
+  "Weekly run specs against main":
     triggers:
       - schedule:
           cron: "0 0 * * 4" # every Thursday
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -28,7 +28,7 @@ if [ ! -d "dummy-app" ]; then
 fi
 
 cd ./dummy-app
-unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-master}" --version '> 0.a'
+unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-main}" --version '> 0.a'
 unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none --no-seed --no-sample "$@"
 unbundled bundle add $extension_name --path ..

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -22,7 +22,7 @@ if [ ! -z $SOLIDUS_BRANCH ]
 then
   BRANCH=$SOLIDUS_BRANCH
 else
-  BRANCH="master"
+  BRANCH="main"
 fi
 
 extension_name="solidus_paypal_commerce_platform"
@@ -47,7 +47,7 @@ if [ ! -d "sandbox" ]; then
 fi
 
 cd ./sandbox
-unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-master}" --version '> 0.a'
+unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-main}" --version '> 0.a'
 unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --payment-method=none --auto-accept "$@"
 unbundled bundle add ${extension_name} --path '../'


### PR DESCRIPTION
## Summary

Stop testing Solidus main with Ruby 2.7. Only >3 is supported.

Use new Solidus default branch. Ref. https://github.com/solidusio/solidus/pull/5042

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
