### PR TITLE
Use the correct spec helper name

### DIFF
--- a/spec/solidus_paypal_commerce_platform_spec_helper.rb
+++ b/spec/solidus_paypal_commerce_platform_spec_helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require 'solidus_starter_frontend_helper'
+require 'solidus_starter_frontend_spec_helper'
 
 Dir["#{__dir__}/support/solidus_paypal_commerce_platform/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
## Summary

The previous helper name is deprecated. All other tests use the correct name.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
