### PR TITLE
Don't try to autoload the deface overrides folder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,6 @@ Rails/Inquiry:
   Enabled: true
   Exclude:
     - spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
+
+Layout/LineLength:
+  Enabled: false

--- a/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
+++ b/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
@@ -92,7 +92,7 @@ module SolidusPaypalCommercePlatform
       private
 
       def solidus_mount_point
-        mount_point = Spree::Core::Engine.routes.find_script_name({})
+        mount_point = ::Spree::Core::Engine.routes.find_script_name({})
         mount_point += "/" unless mount_point.end_with?("/")
         mount_point
       end

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -14,6 +14,10 @@ module SolidusPaypalCommercePlatform
 
     engine_name 'solidus_paypal_commerce_platform'
 
+    initializer "solidus_paypal_commerce_platform.zeitwerk_ignore_deface_overrides", before: :eager_load! do |app|
+      app.autoloaders.main.ignore(root.join('app/overrides'))
+    end
+
     initializer "solidus_paypal_commerce_platform.add_payment_method", after: "spree.register.payment_methods" do |app|
       app.config.to_prepare do
         app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod


### PR DESCRIPTION
## Summary

With Zeitwerk will raise an exception if the right constant is not defined (when eager loading the file).

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
