### PR TITLE
Fix builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,37 +24,36 @@ commands:
           command: |
             export FRONTEND=starter
             sudo gem update --system
-            gem install bundler rails
-            bin/dummy-app
-            bin/rspec
+            gem install bundler rails:'~>7.2'
+            bin/rake
       - solidusio_extensions/store-test-results
 
 jobs:
   run-specs-with-postgres:
     executor:
       name: solidusio_extensions/postgres
-      ruby_version: '3.2'
+      ruby_version: "3.2"
     steps:
       - test-with-starter-frontend
 
   run-specs-with-mysql:
     executor:
       name: solidusio_extensions/mysql
-      ruby_version: '3.1'
+      ruby_version: "3.1"
     steps:
       - test-with-starter-frontend
 
   run-specs-with-sqlite:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: '3.0'
+      ruby_version: "3.1"
     steps:
       - test-with-starter-frontend
 
   lint-code:
     executor:
       name: solidusio_extensions/sqlite-memory
-      ruby_version: '3.0'
+      ruby_version: "3.1"
     steps:
       - solidusio_extensions/lint-code
 

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -14,7 +14,8 @@ function unbundled {
 test "$DB" = "sqlite" && export DB="sqlite3"
 
 rm -rf ./dummy-app
-rails new dummy-app \
+rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
+rails _${rails_version}_ new dummy-app \
   --database=${DB:-sqlite3} \
   --skip-git \
   --skip-keeps \
@@ -33,4 +34,3 @@ unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none --no-seed --no-sample "$@"
 unbundled bundle add $extension_name --path ..
 unbundled bundle exec rails generate $extension_name:install --migrate --specs=all
-

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -8,7 +8,7 @@ require 'solidus_support'
 
 module SolidusPaypalCommercePlatform
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions
+    include ::SolidusSupport::EngineExtensions
 
     isolate_namespace SolidusPaypalCommercePlatform
 
@@ -34,12 +34,12 @@ module SolidusPaypalCommercePlatform
 
     initializer "solidus_paypal_commerce_platform.add_wizard", after: "spree.register.payment_methods" do |app|
       # Adding the class set below - if this is ported to core, we can remove this line.
-      Spree::Core::Environment.add_class_set("payment_setup_wizards")
+      ::Spree::Core::Environment.add_class_set("payment_setup_wizards")
       app.config.spree.payment_setup_wizards << "SolidusPaypalCommercePlatform::Wizard"
     end
 
     initializer "solidus_paypal_commerce_platform.webhooks" do
-      SolidusWebhooks.config.register_webhook_handler :solidus_paypal_commerce_platform, ->(payload) {
+      ::SolidusWebhooks.config.register_webhook_handler :solidus_paypal_commerce_platform, ->(payload) {
         SolidusPaypalCommercePlatform::WebhooksJob.perform_now(payload)
       }
     end

--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deface', '~> 1.5'
   spec.add_dependency 'solidus_api'
   spec.add_dependency 'solidus_core', '>= 3.0', '< 5.0'
-  spec.add_dependency 'solidus_support', '>= 0.8.0'
+  spec.add_dependency 'solidus_support', '>= 0.12.0'
   spec.add_dependency 'solidus_webhooks', '~> 0.2'
 
   spec.add_dependency 'paypalhttp'

--- a/spec/system/backend/new_payment_method_spec.rb
+++ b/spec/system/backend/new_payment_method_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "creating a new payment" do
   end
 
   it "displays the onboarding button", :js do
-    visit "/admin/payment_methods"
+    visit "/admin/payment_methods?solidus_admin=false"
 
     # main_window = current_window
 


### PR DESCRIPTION
- Test with Ruby 3.1, because Solidus now supports Rails 7.2 which needs at least Ruby 3.1.

- Make sure to use Rails 7.2, because Solidus is not yet compatible with Rails 8.0

- Make sure we test admin payment method integrations specs with old backend.
