### PR TITLE
Drop Solidus < 4.1 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 
 AllCops:
   NewCops: disable
-  TargetRubyVersion: '3.0'
+  TargetRubyVersion: "3.1"
   Exclude:
     - sandbox/**/*
     - dummy-app/**/*

--- a/solidus_paypal_commerce_platform.gemspec
+++ b/solidus_paypal_commerce_platform.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_paypal_commerce_platform/releases'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deface', '~> 1.5'
   spec.add_dependency 'solidus_api'
-  spec.add_dependency 'solidus_core', '>= 3.0', '< 5.0'
+  spec.add_dependency 'solidus_core', '>= 4.1', '< 5.0'
   spec.add_dependency 'solidus_support', '>= 0.12.0'
   spec.add_dependency 'solidus_webhooks', '~> 0.2'
 


### PR DESCRIPTION
## Summary

Solidus 4.0 and below are out of support.
Also Ruby 3.0 does not receive any updates.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
