### PR TITLE
CI: Skip all frontend specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ commands:
 
 jobs:
   run-specs-with-postgres:
+    environment:
+      FRONTEND_SPECS: none
     executor:
       name: solidusio_extensions/postgres
       ruby_version: "3.2"
@@ -37,6 +39,8 @@ jobs:
       - test-with-starter-frontend
 
   run-specs-with-mysql:
+    environment:
+      FRONTEND_SPECS: none
     executor:
       name: solidusio_extensions/mysql
       ruby_version: "3.1"
@@ -44,6 +48,8 @@ jobs:
       - test-with-starter-frontend
 
   run-specs-with-sqlite:
+    environment:
+      FRONTEND_SPECS: none
     executor:
       name: solidusio_extensions/sqlite
       ruby_version: "3.1"

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -29,7 +29,7 @@ if [ ! -d "dummy-app" ]; then
 fi
 
 cd ./dummy-app
-unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-main}" --version '> 0.a'
+unbundled bundle add solidus --github tvdeyen/solidus --branch "install-generator-skip-frontend-specs" --version '> 0.a'
 unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none --no-seed --no-sample "$@"
 unbundled bundle add $extension_name --path ..


### PR DESCRIPTION
## Summary

The Solidus dummy app installs the starter frontend which copies all frontend specs and runs them with this extensions specs. These specs are unrelated and wastes unnecessary resources.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
