### PR TITLE
Fix deprecated enum syntax

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/payment_source.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_source.rb
@@ -3,11 +3,11 @@
 module SolidusPaypalCommercePlatform
   class PaymentSource < ::Spree::PaymentSource
     self.table_name = "paypal_commerce_platform_sources"
-    enum paypal_funding_source: {
+    enum :paypal_funding_source, {
       applepay: 0, bancontact: 1, blik: 2, boleto: 3, card: 4, credit: 5, eps: 6, giropay: 7, ideal: 8,
       itau: 9, maxima: 10, mercadopago: 11, mybank: 12, oxxo: 13, p24: 14, paylater: 15, paypal: 16, payu: 17,
       sepa: 18, sofort: 19, trustly: 20, venmo: 21, verkkopankki: 22, wechatpay: 23, zimpler: 24
-    }, _suffix: :funding
+    }, suffix: :funding
     validates :paypal_order_id, :payment_method_id, presence: true
 
     def display_paypal_funding_source

--- a/lib/paypal/paypal_http_client.rb
+++ b/lib/paypal/paypal_http_client.rb
@@ -45,8 +45,7 @@ module PayPal
     end
 
     def _is_auth_request(request)
-      request.path == '/v1/oauth2/token' ||
-        request.path == '/v1/identity/openidconnect/tokenservice'
+      ['/v1/oauth2/token', '/v1/identity/openidconnect/tokenservice'].include?(request.path)
     end
 
     def _has_auth_header(request)


### PR DESCRIPTION
## Summary

This syntax will be removed in Rails 8.0

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
