### PR TITLE
Allow for starter_frontend rename

### DIFF
--- a/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
+++ b/lib/generators/solidus_paypal_commerce_platform/install/install_generator.rb
@@ -16,7 +16,7 @@ module SolidusPaypalCommercePlatform
       def normalize_components_options
         @components = {
           backend: options[:backend],
-          starter_frontend: options[:frontend] == 'starter',
+          storefront: options[:frontend] == 'starter' || options[:frontend] == 'storefront',
           classic_frontend: options[:frontend] == 'classic',
         }
       end
@@ -43,15 +43,21 @@ module SolidusPaypalCommercePlatform
         end
       end
 
-      def install_solidus_starter_frontend_support
-        support_code_for(:starter_frontend) do
+      def install_solidus_storefront_support
+        support_code_for(:storefront) do
           directory 'app', 'app'
+          js_manifest = File.exist?('app/assets/javascripts/solidus_storefront.js') ?
+            'app/assets/javascripts/solidus_storefront.js' :
+            'app/assets/javascripts/solidus_starter_frontend.js'
+          css_manifest = File.exist?('app/assets/stylesheets/solidus_storefront.css') ?
+            'app/assets/stylesheets/solidus_storefront.css' :
+            'app/assets/stylesheets/solidus_starter_frontend.css'
           append_file(
-            'app/assets/javascripts/solidus_starter_frontend.js',
+            js_manifest,
             "//= require spree/frontend/solidus_paypal_commerce_platform\n"
           )
           inject_into_file(
-            'app/assets/stylesheets/solidus_starter_frontend.css',
+            css_manifest,
             " *= require spree/frontend/solidus_paypal_commerce_platform\n",
             before: %r{\*/},
             verbose: true,

--- a/spec/solidus_paypal_commerce_platform_spec_helper.rb
+++ b/spec/solidus_paypal_commerce_platform_spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
-require 'solidus_starter_frontend_spec_helper'
+begin
+  require 'solidus_storefront_spec_helper'
+rescue LoadError
+  require 'solidus_starter_frontend_spec_helper'
+end
 
 Dir["#{__dir__}/support/solidus_paypal_commerce_platform/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
## Summary

As part of merging solidus_starter_frontend into the mono-repo we renamed it to solidus_storefront. This caused some file name issues in this gem that this pull request resolves. Mainly the issue was that the css and js manifest have different paths than they used to. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have localized any and all user-facing strings that I added to the source code.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
